### PR TITLE
Tailor manual build script for python3

### DIFF
--- a/buildLibrealsense.sh
+++ b/buildLibrealsense.sh
@@ -6,9 +6,9 @@
 # Jetson Nano; L4T 32.2.3
 
 LIBREALSENSE_DIRECTORY=${HOME}/librealsense
-LIBREALSENSE_VERSION=v2.31.0
+LIBREALSENSE_VERSION=v2.38.1
 INSTALL_DIR=$PWD
-NVCC_PATH=/usr/local/cuda-10.0/bin/nvcc
+NVCC_PATH=/usr/local/cuda/bin/nvcc
 
 USE_CUDA=true
 
@@ -90,7 +90,7 @@ export CUDACXX=$NVCC_PATH
 export PATH=${PATH}:/usr/local/cuda/bin
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64
 
-/usr/bin/cmake ../ -DBUILD_EXAMPLES=true -DFORCE_LIBUVC=true -DBUILD_WITH_CUDA="$USE_CUDA" -DCMAKE_BUILD_TYPE=release -DBUILD_PYTHON_BINDINGS=bool:true
+/usr/bin/cmake ../ -DBUILD_EXAMPLES=true -DFORCE_LIBUVC=true -DBUILD_WITH_CUDA="$USE_CUDA" -DCMAKE_BUILD_TYPE=release -DBUILD_PYTHON_BINDINGS=bool:true -DPYTHON_EXECUTABLE="/usr/bin/python3"
 
 # The library will be installed in /usr/local/lib, header files in /usr/local/include
 # The demos, tutorials and tests will located in /usr/local/bin.


### PR DESCRIPTION
This is a custom version of JetsonHack's manual RealSense installation script that compiles the bindings specifically for Python3. Using JetsonHack's original version on an OS which had both Python2 and Python3 installed would cause the bindings to be compiled only for Python2.